### PR TITLE
Don't instantiate autoload method

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -40,6 +40,6 @@ class Autoloader
      */
     public static function register(bool $prepend = false)
     {
-        spl_autoload_register([new self(), 'autoload'], true, $prepend);
+        spl_autoload_register([static::class, 'autoload'], true, $prepend);
     }
 }


### PR DESCRIPTION
No need for it in a static methods only class.
